### PR TITLE
Only publish to zot on releases, not pull requests.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
           path: pkg/
           if-no-files-found: error
       - name: Publish zot
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           PUBLISH_USER: ${{ secrets.ZOTHUB_USERNAME }}
           PUBLISH_PASSWORD: ${{ secrets.ZOTHUB_PASSWORD }}


### PR DESCRIPTION
Pull requests would fail here because they do no have access to the credential.