### PR TITLE
Add git to stubby build environment.

### DIFF
--- a/layers/stubby/stacker.yaml
+++ b/layers/stubby/stacker.yaml
@@ -8,7 +8,7 @@ stubby-build-env:
     type: built
     tag: minbase
   run: |
-    pkgtool install binutils gcc gnu-efi libc6-dev make tar
+    pkgtool install binutils gcc git gnu-efi libc6-dev make tar
 
 stubby-build:
   build_only: true


### PR DESCRIPTION
The errors are not fatal, but stubby's build system tries to execute 'git' to get information about itself.