### PR TITLE
Populate shim correctly, fix small issue in Makefile 

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -21,7 +21,7 @@ OCI_D ?= $(BUILD_D)/oci
 STACKER_OPTS = --stacker-dir=$(STACKER_D) --roots-dir=$(ROOTS_D) --oci-dir=$(OCI_D) $(STACKER_COMMON_OPTS)
 STACKER_BUILD = stacker $(STACKER_OPTS) build $(STACKER_BUILD_ARGS) --layer-type=squashfs --layer-type=tar $(STACKER_SUBS)
 STACKER_RBUILD = stacker $(STACKER_OPTS) recursive-build $(STACKER_BUILD_ARGS) --search-dir=layers/ --layer-type=squashfs --layer-type=tar $(STACKER_SUBS)
-STACKER_PUBLISH = stacker $(STACKER_OPTS) publish $(STACKER_BUILD_ARGS) \
+STACKER_PUBLISH = stacker $(STACKER_OPTS) publish \
 	--search-dir=layers/ --layer-type=squashfs $(STACKER_SUBS) \
 	"--username=$(PUBLISH_USER)" "--password=$(PUBLISH_PASSWORD)" \
 	"--url=$(PUBLISH_URL)" --tag=$(MAIN_SERIAL)

--- a/layers/shim/stacker.yaml
+++ b/layers/shim/stacker.yaml
@@ -40,8 +40,7 @@ shim-build:
     cd "$shimd"
 
     # copy build configuration and certs
-    mkdir config
-    cat > config/Make.local <<EOF
+    cat > Make.local <<EOF
     # UEFI shim build configuration
     #
 
@@ -52,8 +51,8 @@ shim-build:
     VENDOR_DB_FILE = $shimd/vendor_db.esl
     EOF
 
-    cat > config/sbat.csv <<EOF
-    config/shim.puzzleos,1,PuzzleOS,shim,15.6-202207-1,https://github.com/puzzleos
+    cat > sbat.csv <<EOF
+    shim.puzzleos,1,PuzzleOS,shim,15.6-202207-1,https://github.com/puzzleos
     EOF
 
     mkdir $shimd/certs
@@ -79,7 +78,6 @@ shim-build:
 
     make
     sha256sum *.efi
-
 
     mkdir $d/shim
     cp $shimd/shimx64.efi $d/shim/shim-unsigned.efi


### PR DESCRIPTION
 *  Fix common.mk so stacker publish does not get STACKER_BUILD_ARGS.
    
    STACKER_BUILD_ARGS was getting passed to 'stacker publish'.
    If you set STACKER_BUILD_ARGS to '--shell-fail', and build did
    not fail, then publish would fail because --shell-fail is not
    valid there.

 *  Fix creation of the shim.
    
    The Make.local was being placed in 'config/' dir under the shim
    source.  The right place is to be in the top level of shim source.
    
    The result was that the shim had no signatures in its db.


