### PR TITLE
Feature/lib modules squashfs

### DIFF
--- a/layers/bootkit/stacker.yaml
+++ b/layers/bootkit/stacker.yaml
@@ -15,7 +15,7 @@ bootkit-assemble:
     - stacker://uki-build/export/uki.tar
     - stacker://ovmf-build/export/ovmf.tar
     - stacker://kernel-build/export/boot.tar
-    - stacker://kernel-build/export/modules.tar
+    - stacker://kernel-build/export/modules.squashfs
   run: |
     #!/bin/bash -ex
     d=$(mktemp -d)
@@ -32,7 +32,7 @@ bootkit-assemble:
     cp "$d/ovmf/ovmf-vars.fd" "$prepd/ovmf-vars.fd"
     cp "$d/ovmf/ovmf-vars-empty.fd" "$prepd/ovmf-vars-empty.fd"
     cp "$d/ovmf/ovmf-code.fd" "$prepd/ovmf-code.fd"
-    cp /stacker/boot.tar /stacker/modules.tar "$prepd"
+    cp /stacker/boot.tar /stacker/modules.squashfs "$prepd"
 
     mkdir /export
     tar -C "$d" -cf /export/bootkit.tar bootkit/

--- a/layers/build-krd/stacker.yaml
+++ b/layers/build-krd/stacker.yaml
@@ -19,6 +19,7 @@ build-krd-pkg:
         cryptsetup-bin 
         kdump-tools 
         lvm2 
+        squashfs-tools
         systemd-sysv 
         # mosctl
         libsquashfs1

--- a/layers/kernel/stacker.yaml
+++ b/layers/kernel/stacker.yaml
@@ -32,7 +32,9 @@ kernel-build:
 
     tar -C "$d" -cf /export/boot.tar boot/$ver/
     tar -C "$d" -cf /export/initrd.tar initrd/
-    tar -C / -cf /export/modules.tar lib/modules/$ver
+
+    ( cd /lib/modules &&
+      mksquashfs $ver/ /export/modules.squashfs -xattrs -comp xz -keep-as-directory )
     echo "$ver" > /export/version
 
     rm -Rf "$d"

--- a/pkg/cmd/oci-boot/main.go
+++ b/pkg/cmd/oci-boot/main.go
@@ -898,6 +898,14 @@ func (o *OciBoot) Populate(target string) error {
 		}
 	}
 
+	modSquashDest := path.Join(target, "krd", "modules.squashfs")
+	if err := os.MkdirAll(filepath.Dir(modSquashDest), 0755); err != nil {
+		return fmt.Errorf("Failed to create directory for modules.squashfs: %v", err)
+	}
+	if err := copyFile(filepath.Join(o.bootKitDir, "bootkit/modules.squashfs"), modSquashDest); err != nil {
+		return fmt.Errorf("Failed to copy modules.squashfs to media: %v", err)
+	}
+
 	for src, dest := range o.Files {
 		if err := copyFile(src, path.Join(target, dest)); err != nil {
 			return fmt.Errorf("Failed to copy file '%s' to iso path '%s': %w", src, dest, err)

--- a/pkg/cmd/oci-boot/main.go
+++ b/pkg/cmd/oci-boot/main.go
@@ -524,7 +524,7 @@ func (o *OciBoot) CreateDisk(diskFile string, opts DiskOptions) error {
 	if err != nil {
 		return err
 	}
-	// defer os.RemoveAll(tmpd)
+	defer os.RemoveAll(tmpd)
 
 	if err := o.Populate(tmpd); err != nil {
 		return err


### PR DESCRIPTION
  * Change kernel modules from tar to squashfs and add it to boot media.
    
    The dracut soci kernel module already had support for mounting kernel
    modules at /krd/modules.squashfs to /lib/modules.  It will do that
    if the file exists.
    
    The big change here is in the bootkit produced layers, as now we
    are creating a 'modules.squashfs' rather than 'modules.tar'.
    
    In the future maybe we want to make oci-boot configurable to *not*
    copy the modules, but right now we will just always copy the kernel
    modules and the soci module mounts them if they are there.

  * Remove temporary directory.
    
    This had just been left in place during debugging.


