### PR TITLE
Switch to using trust-generated keys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ jobs:
         run: |
           sudo add-apt-repository -y ppa:project-machine/squashfuse
           sudo apt-get install squashfuse
+          wget https://github.com/project-machine/keys/archive/refs/heads/snakeoil.tar.gz
+          mkdir -p ~/.local/share/machine/trust/keys
+          (cd ~/.local/share/machine/trust/keys; tar zxf ~/snakeoil.tar.gz; mv keys-snakeoil snakeoil)
           sudo wget --progress=dot:mega -O /usr/bin/stacker \
               https://github.com/project-stacker/stacker/releases/download/v1.0.0-rc4/stacker
           sudo chmod 755 /usr/bin/stacker

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # bootkit
 
 ## bootkit layer
-The build of bootkit uses a reference to a 'keys' tarball like seen
-at https://github.com/project-machine/keys/tree/snakeoil/
+The build of bootkit uses a (named) keyset as created by
+(trust)[https://github.com/project-machine/trust].
 
-This can be defined by substituting KEYS_REPO during the stacker build.
+This can be defined by substituting KEYSET during the stacker build.
 
 Bootkit publishes a oci image that contains these files:
  * boot.tar - tarball of normal linux distribution boot/ files.
@@ -29,7 +29,8 @@ After building bootkit and building oci-boot, you can do:
 
 ## Build
 Things that can be defined during this build:
- * KEYS_REPO - default value is https://github.com/project-machine/keys/tree/snakeoil/
+ * KEYSET - default value snakeoil.  For this to work, you should first
+   run "trust keyset add snakeoil".
  * DOCKER_BASE - this should reference a docker url that has 'ubuntu:jammy' in it
    ie, setting to 'docker://' (the default) would use the official docker repos.
  * UBUNTU_MIRROR - this is a url to a ubuntu package mirror.

--- a/layers/ovmf/stacker.yaml
+++ b/layers/ovmf/stacker.yaml
@@ -17,16 +17,18 @@ ovmf-build:
     type: built
     tag: ovmf-build-env
   import:
-    - ${{KEYS_REPO:https://github.com/project-machine/keys/archive/refs/heads/snakeoil.tar.gz}}
+    - path: ${{HOME}}/.local/share/machine/trust/keys/${{KEYSET}}/
+      dest: /keysimport/
   run: |
     d=$(mktemp -d)
     trap "rm -Rf $d" EXIT
 
-    mkdir "$d/ovmf" "$d/x"
-    tar -C "$d/x" -xf /stacker/*.tar.gz
-    keysdir=$(echo "$d/x"/*)
-    [ -d "$keysdir" ] || { echo "not exactly one dir in keys input"; exit 1; }
+    mkdir "$d/ovmf"
+    mv /keysimport/${{KEYSET}} /keys
+    keysdir="/keys"
 
+    echo xxx
+    ls -l /keys
     getGuidCert() {
       local kd="$1" n="$2" guid="" guidf="" certf=""
       certf="$kd/$n/cert.pem"

--- a/layers/shim/stacker.yaml
+++ b/layers/shim/stacker.yaml
@@ -22,17 +22,15 @@ shim-build:
     type: built
     tag: shim-build-env
   import:
-    - ${{KEYS_REPO:https://github.com/project-machine/keys/archive/refs/heads/snakeoil.tar.gz}}
+    - path: ${{HOME}}/.local/share/machine/trust/keys/${{KEYSET}}/
+      dest: /keysimport/
   run: |
     d=$(mktemp -d)
     trap "rm -Rf $d" EXIT
 
     cd $d
-    mkdir x
-    cd x
-    tar -xf /stacker/*.tar.gz
-    keydir=$(echo $d/x/*)
-    [ -d "$keydir" ] || { echo "bad keys import. didn't have a single top level dir"; exit 1; }
+    mv /keysimport/${{KEYSET}} /keys
+    keydir="/keys"
 
     shimd=$(echo /build/shim-*)
     [ -d "$shimd" ] || { echo "no single shim dir in /build"; exit 1; }

--- a/layers/uki/stacker.yaml
+++ b/layers/uki/stacker.yaml
@@ -14,8 +14,9 @@ uki-build:
     - stacker://kernel-build/export/boot.tar
     - stacker://kernel-build/export/initrd.tar
     - stacker://stubby-build/export/stubby.tar
-    - ${{KEYS_REPO:https://github.com/project-machine/keys/archive/refs/heads/snakeoil.tar.gz}}
     - ${{MOSCTL_BINARY:https://github.com/project-machine/mos/releases/download/0.0.7/mosctl}}
+    - path: ${{HOME}}/.local/share/machine/trust/keys/${{KEYSET}}/
+      dest: /keysimport/
   run: |
     #!/bin/bash -ex
     d=$(mktemp -d)
@@ -36,15 +37,8 @@ uki-build:
         rm "$d/imports/$e"
     done
 
-    set -- $d/imports/*
-    [ $# -eq 0 ] && { echo "no key import found"; exit 1; }
-    [ $# -eq 1 ] || { echo "found imports that could be a key: $*"; exit 1; }
-    keyimport=$1
-
-    mkdir "$d/keyx"
-    tar -C "$d/keyx" -xf "$keyimport"
-    keydir=$(echo "$d/keyx"/*)
-    [ -d "$keydir" ] || { echo "found not exactly one dir in $keyimport"; exit 1; }
+    mv /keysimport/${{KEYSET}} /keys
+    keydir=/keys
 
     initrd_d="$d/initrd"
     tar -C "$d" -xf /stacker/initrd.tar

--- a/subs.mk
+++ b/subs.mk
@@ -1,7 +1,11 @@
+KEYSET ?= snakeoil
 DOCKER_BASE ?= docker://
 UBUNTU_MIRROR ?= http://archive.ubuntu.com/ubuntu
+HOME ?= \$HOME
 
 STACKER_SUBS = \
+	--substitute=KEYSET=$(KEYSET) \
 	--substitute=DOCKER_BASE=$(DOCKER_BASE) \
 	--substitute=UBUNTU_MIRROR=$(UBUNTU_MIRROR) \
+	--substitute=HOME=$(HOME) \
 	--substitute=TOP_D=$(TOP_D)


### PR DESCRIPTION
Switch the build to use keys as specified by 'keyset name'. The default is 'snakeoil'.  You must first
   'trust keyset add snakeoil'.
It should be possible to have Makefile auto-fetch that if needed, but I'm not doing that here.