### PR TITLE
Cleanup/misc cleanups

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,14 +20,16 @@ jobs:
         run: |
           sudo add-apt-repository -y ppa:project-machine/squashfuse
           sudo apt-get install squashfuse
-          wget https://github.com/project-machine/trust/releases/download/0.0.3/trust
-          chmod 755 trust
-          ./trust keyset add snakeoil
           sudo wget --progress=dot:mega -O /usr/bin/stacker \
               https://github.com/project-stacker/stacker/releases/download/v1.0.0-rc4/stacker
           sudo chmod 755 /usr/bin/stacker
           which stacker
           stacker --version
+
+          sudo wget --progress=dot:mega -O /usr/bin/trust \
+              https://github.com/project-machine/trust/releases/download/0.0.3/trust
+          sudo chmod 755 /usr/bin/trust
+          trust keyset add snakeoil
       - name: build bootkit
         run: |
           make STACKER_COMMON_OPTS=--debug

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 The build of bootkit uses a (named) keyset as created by
 (trust)[https://github.com/project-machine/trust].
 
-This can be defined by substituting KEYSET during the stacker build.
+This can be defined by substituting KEYSET_D during the stacker build.
 
 Bootkit publishes a oci image that contains these files:
  * boot.tar - tarball of normal linux distribution boot/ files.
@@ -29,8 +29,9 @@ After building bootkit and building oci-boot, you can do:
 
 ## Build
 Things that can be defined during this build:
- * KEYSET - default value snakeoil.  For this to work, you should first
-   run "trust keyset add snakeoil".
+ * KEYSET_D - Make sets this to the user's machine/trust/keys/snakeoil
+   directory.  The keyset (snakeoil) can be changed by setting KEYSET
+   variable to make (`make KEYSET=myset`).
  * DOCKER_BASE - this should reference a docker url that has 'ubuntu:jammy' in it
    ie, setting to 'docker://' (the default) would use the official docker repos.
  * UBUNTU_MIRROR - this is a url to a ubuntu package mirror.

--- a/layers/ovmf/stacker.yaml
+++ b/layers/ovmf/stacker.yaml
@@ -17,24 +17,22 @@ ovmf-build:
     type: built
     tag: ovmf-build-env
   import:
-    - path: ${{HOME}}/.local/share/machine/trust/keys/${{KEYSET}}/
-      dest: /keysimport/
+    - path: ${{KEYSET_D}}/
+      dest: /import/keys/
   run: |
     d=$(mktemp -d)
     trap "rm -Rf $d" EXIT
 
     mkdir "$d/ovmf"
-    mv /keysimport/${{KEYSET}} /keys
-    keysdir="/keys"
+    keydir=$(echo /import/keys/*)
+    [ -d "$keydir" ]
 
-    echo xxx
-    ls -l /keys
     getGuidCert() {
       local kd="$1" n="$2" guid="" guidf="" certf=""
       certf="$kd/$n/cert.pem"
       guidf="$kd/$n/guid"
       [ -d "$kd/$n" ] || {
-          echo "ERROR: no '$n' dir in $keysdir" 1>&2
+          echo "ERROR: no '$n' dir in $keydir" 1>&2
           return 1
       }
       [ -f "$certf" ] || {
@@ -64,9 +62,9 @@ ovmf-build:
     cp "$varsf" "$d/ovmf/ovmf-vars-empty.fd"
     set +x
     set -- \
-       --set-pk  $(getGuidCert "$keysdir" uefi-pk) \
-       --add-kek $(getGuidCert "$keysdir" uefi-kek) \
-       --add-db  $(getGuidCert "$keysdir" uefi-db)
+       --set-pk  $(getGuidCert "$keydir" uefi-pk) \
+       --add-kek $(getGuidCert "$keydir" uefi-kek) \
+       --add-db  $(getGuidCert "$keydir" uefi-db)
     [ $# -eq 9 ] || { echo "getting keys failed $#: $*" 1>&2; exit 1; }
 
     set -x

--- a/layers/shim/stacker.yaml
+++ b/layers/shim/stacker.yaml
@@ -22,15 +22,15 @@ shim-build:
     type: built
     tag: shim-build-env
   import:
-    - path: ${{HOME}}/.local/share/machine/trust/keys/${{KEYSET}}/
-      dest: /keysimport/
+    - path: ${{KEYSET_D}}/
+      dest: /import/keys/
   run: |
     d=$(mktemp -d)
     trap "rm -Rf $d" EXIT
 
     cd $d
-    mv /keysimport/${{KEYSET}} /keys
-    keydir="/keys"
+    keydir=$(echo /import/keys/*)
+    [ -d "$keydir" ]
 
     shimd=$(echo /build/shim-*)
     [ -d "$shimd" ] || { echo "no single shim dir in /build"; exit 1; }

--- a/layers/uki/stacker.yaml
+++ b/layers/uki/stacker.yaml
@@ -17,31 +17,23 @@ uki-build:
     - ${{MOSCTL_BINARY:https://github.com/project-machine/mos/releases/download/0.0.9/mosctl}}
     - https://github.com/project-zot/zot/releases/download/v1.4.3/zot-linux-amd64-minimal
     - zot-config.json
-    - path: ${{HOME}}/.local/share/machine/trust/keys/${{KEYSET}}/
-      dest: /keysimport/
+    - path: ${{KEYSET_D}}/
+      dest: /import/keys/
   run: |
     #!/bin/bash -ex
     d=$(mktemp -d)
     cd "$d"
     trap "rm -Rf $d" EXIT
 
+    keydir=$(echo /import/keys/*)
+    [ -d "$keydir" ]
+
     mkdir $d/export
 
     # basically find the 'keys' import by filtering out everything else we expect to be there.
     nonkeys="boot initrd stubby"
     bins="mosctl"
-    mkdir $d/imports
     mkdir /zot-cache
-    ln -s /stacker/* $d/imports/
-    for e in $nonkeys; do
-        rm -f $d/imports/$e.tar
-    done
-    for e in $bins; do
-        rm "$d/imports/$e"
-    done
-
-    mv /keysimport/${{KEYSET}} /keys
-    keydir=/keys
 
     initrd_d="$d/initrd"
     tar -C "$d" -xf /stacker/initrd.tar

--- a/subs.mk
+++ b/subs.mk
@@ -1,7 +1,6 @@
 KEYSET ?= snakeoil
 DOCKER_BASE ?= docker://
 UBUNTU_MIRROR ?= http://archive.ubuntu.com/ubuntu
-HOME ?= \$HOME
 
 STACKER_SUBS = \
 	--substitute=KEYSET=$(KEYSET) \

--- a/subs.mk
+++ b/subs.mk
@@ -1,9 +1,10 @@
 KEYSET ?= snakeoil
 DOCKER_BASE ?= docker://
 UBUNTU_MIRROR ?= http://archive.ubuntu.com/ubuntu
+KEYSET_D ?= $(HOME)/.local/share/machine/trust/keys/$(KEYSET)
 
 STACKER_SUBS = \
-	--substitute=KEYSET=$(KEYSET) \
+	--substitute=KEYSET_D=$(KEYSET_D) \
 	--substitute=DOCKER_BASE=$(DOCKER_BASE) \
 	--substitute=UBUNTU_MIRROR=$(UBUNTU_MIRROR) \
 	--substitute=HOME=$(HOME) \


### PR DESCRIPTION
  * Use KEYSET_D in substitution and keys-dir usage changes.
    
    Note here we do:
    
        import:
          - path: ${{KEYSET_D}}/
            dest: /import/keys
    
    My feeling is that this *should* produce /import/keys with the
    same content as KEYSET_D.  However, the behavior of stacker 1.0.0-v4
    is to create /import/keys/$(basename ${{KEYSET_D}}).
    I think that is incorrect behavior as we would like to specify
    the target "dest" independent of the source path.
    
    If that were fixed, then we wouldn't need the 'keydir=$(echo ...)'
    but rather just explicitly set it to 'keydir=/import/keys'.
    
    https://github.com/project-stacker/stacker/issues/455
    
    Also here is to use 'keydir' consistently (some places had keysdir).

  * workflow: install 'trust' into /usr/bin
    
    This puts 'trust' executable in the PATH and makes it
    usable.  Downloads it with much less verbosity.

  * subs.mk: drop incorrect definition of HOME.
    
    The make syntax 'NAME ?= value' says "if variable NAME is set
    then do not change it, otherwise set it to value".
    
    So `HOME ?= \$HOME` is weird at best, and in my limited testing
    doesn't work; it ends up setting HOME to literal '\' followed
    by the value of the variable H followed by literal 'OME'.
    
        $ cat my.mk
        FOO ?= \$HOME
        debug:
                @printf "%s\n" "FOO=$(FOO)"
    
        $ make -f my.mk
        FOO=\OME
    
        $ H=WhenInR make -f my.mk
        FOO=\WhenInROME


