### PR TITLE
Address feedback from #21

### DIFF
--- a/layers/build-krd/dracut/soci/README.md
+++ b/layers/build-krd/dracut/soci/README.md
@@ -43,7 +43,7 @@ You can mount that with:
     root=soci:name=rootfs-soci,dev=LABEL=oci-data,path=oci-data
 
 ## Notes
- * This module's install does *not* copy in all it's dependencies.  This is
+ * This module's install does *not* copy in all its dependencies.  This is
    so that those can be added to the initramfs later.  Specifically,
    the root=soci functionality depends on mosctl and zot binaries.
 

--- a/layers/build-krd/dracut/soci/soci-settled.sh
+++ b/layers/build-krd/dracut/soci/soci-settled.sh
@@ -247,19 +247,22 @@ soci_udev_settled() {
             }
         done
 
-        # copy the pcr7data to persist past initramfs
-        mkdir -p /run/machine && cp -r /pcr7data /run/machine/ || {
-            soci_die "Unable to copy pcr7data to /run/machine"
-            return 1
-        }
-        ## FIXME - I don't like the polution of target's /
-        ln -s /run/machine/pcr7data /pcr7data || {
-            soci_die "Failed to symlink /pcr7data -> /run/machine/pcr7data"
+        mkdir -p "${rootd}/factory/secure"
+        cp -f /manifestCA.pem "${rootd}/factory/secure/"
+
+        # copy the pcr7data to persist past initramfs. we expect this to change.
+        mkdir -p "$rootd/factory/initrd" &&
+            cp -r /pcr7data "$rootd/factory/initrd/pcr7data" || {
+                soci_die "Unable to copy pcr7data to /run/machine"
+                return 1
+            }
+        ## FIXME - I don't like the pollution of target's /,  but right now
+        ## 'trust provision' expects data at /pcr7data.
+        ln -s "/factory/initrd/pcr7data" "$rootd/pcr7data" || {
+            soci_die "Failed to symlink /pcr7data -> /factory/initrd/pcr7data"
             return 1
         }
 
-        mkdir -p "${rootd}/factory/secure"
-        cp -f /manifestCA.pem "${rootd}/factory/secure/"
 
         soci_log_run cat /proc/modules
         soci_log_run ls -l /sysroot


### PR DESCRIPTION
  * dracut/soci: copy pcr7data to /factory/initrd/pcr7data , fix symlink
    
    Addresses some of the comments in
       https://github.com/project-machine/bootkit/pull/21
    
    The symlink was being created in initramfs's /pcr7data which was
    not going to be useful after the pivot.  Fix that symlink to
    be into the target root.

  * doc: fix spelling / incorrect use of contraction
    
    its here is possessive, not a contraction.
