### PR TITLE
faster shim build, layer-<name> targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,16 @@ include common.mk
 build:
 	$(STACKER_RBUILD)
 
+LAYERS := $(shell cd $(TOP_D)/layers && \
+				  for d in *; do [ -f "$$d/stacker.yaml" ] && echo "$$d"; done )
+
+# probably too clever, but the foreach expands to layer-kernel layer-shim ...
+# and then $@ replaces 'layer-' with 'layers/' resulting in
+#   --stacker-file=layers/<layer>/stacker.yaml
+# The result is you can 'make layer-shim' and also tab-complete that.
+$(foreach d,$(LAYERS),layer-$(d)):
+	@echo $(STACKER_BUILD) "--stacker-file=$(@:layer-=layers/)*/stacker.yaml"
+
 .PHONY: publish
 publish:
 	@$(call required_var,PUBLISH_USER)

--- a/common.mk
+++ b/common.mk
@@ -19,7 +19,7 @@ OCI_D ?= $(BUILD_D)/oci
 # STACKER_COMMON_OPTS = --debug
 # STACKER_BUILD_ARGS = --shell-fail
 STACKER_OPTS = --stacker-dir=$(STACKER_D) --roots-dir=$(ROOTS_D) --oci-dir=$(OCI_D) $(STACKER_COMMON_OPTS)
-STACKER_BUILD = stacker $(STACKER_OPTS) build $(STACKER_BUILD_ARGS) --layer-type=squashfs --layer-type=tar $(STACKER_SUBS)
+STACKER_BUILD = stacker $(STACKER_OPTS) build $(STACKER_BUILD_ARGS) --layer-type=squashfs --layer-type=tar --layer-type=squashfs $(STACKER_SUBS)
 STACKER_RBUILD = stacker $(STACKER_OPTS) recursive-build $(STACKER_BUILD_ARGS) --search-dir=layers/ --layer-type=squashfs --layer-type=tar $(STACKER_SUBS)
 STACKER_PUBLISH = stacker $(STACKER_OPTS) publish \
 	--search-dir=layers/ --layer-type=squashfs $(STACKER_SUBS) \

--- a/layers/shim/stacker.yaml
+++ b/layers/shim/stacker.yaml
@@ -74,7 +74,9 @@ shim-build:
     cd $shimd
     cat sbat.csv >> data/sbat.csv && cat data/sbat.csv
 
-    make
+    ncpus=$(grep -c processor /proc/cpuinfo) || ncpus=1
+    make "-j${ncpus}"
+
     sha256sum *.efi
 
     mkdir $d/shim


### PR DESCRIPTION
  * Make shim build much faster with -j.
    
    Shim build is much faster with -j build.

  * Add a layer-<name> target to Makefile
    
    This makes you able to 'make layer-kernel' and have it just make that  layer.
    
    Because the targets are identified, you can also 'make layer-<tab>'.
