### PR TITLE
Install pcr7 info as cpio

### DIFF
--- a/layers/build-krd/dracut/soci/module-setup.sh
+++ b/layers/build-krd/dracut/soci/module-setup.sh
@@ -34,6 +34,7 @@ install() {
         tpm2_policyauthorize tpm2_policynv tpm2_policypcr \
         tpm2_startauthsession tpm2_verifysignature tpm2_nvwrite
     inst /usr/lib/x86_64-linux-gnu/libtss2-tcti-device.so.0
+    inst cpio
     inst curl
     inst git # needed for manifest reading, for now
     #inst /usr/ib/git-core/git-upload-pack

--- a/layers/build-krd/dracut/soci/soci-cmdline.sh
+++ b/layers/build-krd/dracut/soci/soci-cmdline.sh
@@ -15,6 +15,8 @@ soci_initrd_start() {
         command -v "$dep" >/dev/null 2>&1 || missing="$missing, binary '$dep'"
     done
 
+    mkdir -p /pcr7data
+    (cd /pcr7data; cpio -id < /etc/pcr7data.cpio)
     for dep in /pcr7data/ /manifestCA.pem ; do
         [ -e "$dep" ] || missing="$missing, path '$dep'"
     done

--- a/layers/build-krd/dracut/soci/soci-settled.sh
+++ b/layers/build-krd/dracut/soci/soci-settled.sh
@@ -239,10 +239,12 @@ soci_udev_settled() {
 
 
         # move the mounts under the new root so switch_root does not delete contents
+        # cannot move-mount out of a shared parent mount, so make sure / is private
+        mount --make-private /
         for d in config scratch-writes atomfs-store; do
             mkdir -p "/$rootd/$d"
             mount --move "/$d" "$rootd/$d" || {
-                soci_die "Unable to mount --move /$d $root/$d"
+                soci_die "Unable to mount --move /$d $rootd/$d"
                 return 1
             }
         done

--- a/layers/uki/stacker.yaml
+++ b/layers/uki/stacker.yaml
@@ -51,9 +51,13 @@ uki-build:
         { echo "stubby.tar did not have a stubby/stubby.efi"; exit 1; }
 
     keyworkd="$d/keyworkd"
-    mkdir "$keyworkd"
+    mkdir -p "$keyworkd/etc"
     cp "$keydir/manifest-ca/cert.pem" "$keyworkd/manifestCA.pem"
-    cp -r "$keydir/pcr7data" "$keyworkd/pcr7data"
+    # For some reason, copying the directory doesn't seem to work.
+    # The kernel ends up not unpacking it.
+    # Also, create-cpio always compresses, but this must not be compressed,
+    # so do it by hand.
+    (cd "$keydir/pcr7data"; find . | cpio -o -H newc > "$keyworkd/etc/pcr7data.cpio")
 
     create-cpio "$keyworkd" "$initrd_d/keys.cpio.gz"
 


### PR DESCRIPTION
I have no idea why this is happening, but when we simply insert pcr7data directory as is, it *is* in the initrd (as can be verified by extracting kernel.efi), but the kernel's initrd unpacker does not create it.  I've tried moving it to /etc/, still doesn't show up.  My only guess, although I see no such limitation in init/initramfs.c, is that the long directory filenames are a problem.

To work around this, create /etc/pcr7data.cpio inside the initrd.cpio, and unpack it during soci-cmdline.sh.

With this, the livecd testcase in my mos PR works.