### PR TITLE
revert "Install pcr7 info as cpio"

### DIFF
--- a/layers/build-krd/dracut/soci/module-setup.sh
+++ b/layers/build-krd/dracut/soci/module-setup.sh
@@ -34,7 +34,6 @@ install() {
         tpm2_policyauthorize tpm2_policynv tpm2_policypcr \
         tpm2_startauthsession tpm2_verifysignature tpm2_nvwrite
     inst /usr/lib/x86_64-linux-gnu/libtss2-tcti-device.so.0
-    inst cpio
     inst curl
     inst git # needed for manifest reading, for now
     #inst /usr/ib/git-core/git-upload-pack

--- a/layers/build-krd/dracut/soci/soci-cmdline.sh
+++ b/layers/build-krd/dracut/soci/soci-cmdline.sh
@@ -15,8 +15,6 @@ soci_initrd_start() {
         command -v "$dep" >/dev/null 2>&1 || missing="$missing, binary '$dep'"
     done
 
-    mkdir -p /pcr7data
-    (cd /pcr7data; cpio -id < /etc/pcr7data.cpio)
     for dep in /pcr7data/ /manifestCA.pem ; do
         [ -e "$dep" ] || missing="$missing, path '$dep'"
     done

--- a/layers/build-krd/dracut/soci/soci-settled.sh
+++ b/layers/build-krd/dracut/soci/soci-settled.sh
@@ -239,10 +239,12 @@ soci_udev_settled() {
 
 
         # move the mounts under the new root so switch_root does not delete contents
+        # cannot move-mount out of a shared parent mount, so make sure / is private
+        mount --make-private /
         for d in config scratch-writes atomfs-store; do
             mkdir -p "/$rootd/$d"
             mount --move "/$d" "$rootd/$d" || {
-                soci_die "Unable to mount --move /$d $root/$d"
+                soci_die "Unable to mount --move /$d $rootd/$d"
                 return 1
             }
         done

--- a/layers/build-krd/dracut/soci/soci-settled.sh
+++ b/layers/build-krd/dracut/soci/soci-settled.sh
@@ -239,12 +239,10 @@ soci_udev_settled() {
 
 
         # move the mounts under the new root so switch_root does not delete contents
-        # cannot move-mount out of a shared parent mount, so make sure / is private
-        mount --make-private /
         for d in config scratch-writes atomfs-store; do
             mkdir -p "/$rootd/$d"
             mount --move "/$d" "$rootd/$d" || {
-                soci_die "Unable to mount --move /$d $rootd/$d"
+                soci_die "Unable to mount --move /$d $root/$d"
                 return 1
             }
         done

--- a/layers/uki/stacker.yaml
+++ b/layers/uki/stacker.yaml
@@ -51,13 +51,9 @@ uki-build:
         { echo "stubby.tar did not have a stubby/stubby.efi"; exit 1; }
 
     keyworkd="$d/keyworkd"
-    mkdir -p "$keyworkd/etc"
+    mkdir "$keyworkd"
     cp "$keydir/manifest-ca/cert.pem" "$keyworkd/manifestCA.pem"
-    # For some reason, copying the directory doesn't seem to work.
-    # The kernel ends up not unpacking it.
-    # Also, create-cpio always compresses, but this must not be compressed,
-    # so do it by hand.
-    (cd "$keydir/pcr7data"; find . | cpio -o -H newc > "$keyworkd/etc/pcr7data.cpio")
+    cp -r "$keydir/pcr7data" "$keyworkd/pcr7data"
 
     create-cpio "$keyworkd" "$initrd_d/keys.cpio.gz"
 


### PR DESCRIPTION
Revert changes made under #24, and then put one set back in.

  * Use 'mount --make-private /' and fix error message.
    
    Add these chanages from 355a386821959 back.
    
    These came from the reverted commit, but are not related to the
    insertion problems with pcr7data not showing up in kernel extracted
    initramfs.

 *   Revert "Install pcr7 info as cpio"
    
     This reverts commit 355a386821959030066bb80361f8c5793fdef762.
