### PR TITLE
soci-settled: fix typo

### DIFF
--- a/layers/build-krd/dracut/soci/soci-settled.sh
+++ b/layers/build-krd/dracut/soci/soci-settled.sh
@@ -189,6 +189,10 @@ soci_udev_settled() {
         chmod 700 /factory/secure
         cp /manifestCA.pem /factory/secure/
 
+        # cannot move-mount out of a shared parent mount, so make sure / is
+        # private before we try a move-mount
+        mount --make-private /
+
         if [ "$name" = "mosboot" ]; then
             mount_boot_rootfs
             exit 1
@@ -239,8 +243,6 @@ soci_udev_settled() {
 
 
         # move the mounts under the new root so switch_root does not delete contents
-        # cannot move-mount out of a shared parent mount, so make sure / is private
-        mount --make-private /
         for d in config scratch-writes atomfs-store; do
             mkdir -p "/$rootd/$d"
             mount --move "/$d" "$rootd/$d" || {

--- a/layers/build-krd/dracut/soci/soci-settled.sh
+++ b/layers/build-krd/dracut/soci/soci-settled.sh
@@ -125,7 +125,7 @@ mount_boot_rootfs() {
         return 1
     fi
 
-    mkdir -p $rootfd/boot/efi
+    mkdir -p $rootd/boot/efi
     mount --move /boot/efi $rootd/boot/efi
 }
 


### PR DESCRIPTION
The variable name typo results in 'mkdir /boot/efi', so /sys/root/boot/efi' is not getting created.  This led to:

[    3.487601] dracut-initqueue[401]: mount: /sysroot/boot/efi: mount point does not exist.