### PR TITLE
Allow MOSCTL_BINARY and ZOT_BINARY to be read from the environment.

### DIFF
--- a/layers/mos/stacker.yaml
+++ b/layers/mos/stacker.yaml
@@ -8,8 +8,10 @@ mos-build:
     type: built
     tag: build-krd
   import:
-    - ${{MOSCTL_BINARY:https://github.com/project-machine/mos/releases/download/0.0.9/mosctl}}
-    - ${{ZOT_BINARY:https://github.com/project-zot/zot/releases/download/v1.4.3/zot-linux-amd64-minimal}}
+    - path: ${{MOSCTL_BINARY}}
+      dest: /imports/mosctl/
+    - path: ${{ZOT_BINARY}}
+      dest: /imports/zot/
     - zot-config.json
   run: |
     d=$(mktemp -d)
@@ -23,10 +25,19 @@ mos-build:
     cp /stacker/zot-config.json "$workd/etc/"
 
     mkdir -p "$workd/usr/bin"
-    for bin in mosctl:mosctl zot-linux-amd64-minimal:zot ; do
-      t=$workd/usr/bin/${bin#*:}
-      cp -v /stacker/${bin%:*} $t
-      chmod 755 $t
+
+    # working around https://github.com/project-stacker/stacker/issues/456
+    for bin in mosctl zot; do
+      t="$workd/usr/bin/$bin"
+      src=$(echo /imports/$bin/*)
+      [ -f "$src" ] || {
+        echo "import for $bin: was not a file"
+        echo "glob resolved to: $src"
+        echo "/imports/$bin/ has:"
+        ls -l /imports/$bin/
+      }
+      cp -v "$src" "$t"
+      chmod 755 "$t"
     done
 
     # dracut-install will pick up all the deps for these binaries

--- a/subs.mk
+++ b/subs.mk
@@ -2,6 +2,8 @@ KEYSET ?= snakeoil
 DOCKER_BASE ?= docker://
 UBUNTU_MIRROR ?= http://archive.ubuntu.com/ubuntu
 KEYSET_D ?= $(HOME)/.local/share/machine/trust/keys/$(KEYSET)
+MOSCTL_BINARY ?= https://github.com/project-machine/mos/releases/download/0.0.9/mosctl
+ZOT_BINARY ?= https://github.com/project-zot/zot/releases/download/v1.4.3/zot-linux-amd64-minimal
 
 STACKER_SUBS = \
 	--substitute=KEYSET_D=$(KEYSET_D) \
@@ -9,4 +11,6 @@ STACKER_SUBS = \
 	--substitute=UBUNTU_MIRROR=$(UBUNTU_MIRROR) \
 	--substitute=HOME=$(HOME) \
 	--substitute=KEYS_DIR=$(HOME)/.local/share/machine/trust/keys \
-	--substitute=TOP_D=$(TOP_D)
+	--substitute=TOP_D=$(TOP_D) \
+	--substitute=MOSCTL_BINARY=$(MOSCTL_BINARY) \
+	--substitute=ZOT_BINARY=$(ZOT_BINARY)


### PR DESCRIPTION
This allows user that invokes make to influence the mosctl and zot binary via MOSCTL_BINARY and ZOT_BINARY variables respectively.

The make variables will take the values present in the environment or on the make command line if provided.

So either:

    export MOSCTL_BINARY=/tmp/my-mosctl
    export ZOT_BINARY=http://...

or

    make MOSCTL_BINARY=... ZOT_BINARY=...