### PR TITLE
Drop unused substitution KEYS_DIR.

### DIFF
--- a/subs.mk
+++ b/subs.mk
@@ -10,7 +10,6 @@ STACKER_SUBS = \
 	--substitute=DOCKER_BASE=$(DOCKER_BASE) \
 	--substitute=UBUNTU_MIRROR=$(UBUNTU_MIRROR) \
 	--substitute=HOME=$(HOME) \
-	--substitute=KEYS_DIR=$(HOME)/.local/share/machine/trust/keys \
 	--substitute=TOP_D=$(TOP_D) \
 	--substitute=MOSCTL_BINARY=$(MOSCTL_BINARY) \
 	--substitute=ZOT_BINARY=$(ZOT_BINARY)


### PR DESCRIPTION
KEYS_DIR was replaced with KEYSET_D, but wasn't removed from the subs.mk file.