### PR TITLE
Arm64 changes built on top of older commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 NAME := bootkit
 
+ARCH := $(shell uname -m )
+
 include subs.mk
 include common.mk
 

--- a/layers/bootkit/stacker.yaml
+++ b/layers/bootkit/stacker.yaml
@@ -3,7 +3,7 @@ config:
     - ../kernel/stacker.yaml
     - ../shim/stacker.yaml
     - ../uki/stacker.yaml
-    - ../ovmf/stacker.yaml
+    - ../virt-firmware/stacker.yaml
 
 bootkit-assemble:
   build_only: true
@@ -13,7 +13,7 @@ bootkit-assemble:
   import:
     - stacker://shim-build/export/shim.tar
     - stacker://uki-build/export/uki.tar
-    - stacker://ovmf-build/export/ovmf.tar
+    - stacker://virt-firmware-build/export/virt-firmware.tar
     - stacker://kernel-build/export/boot.tar
     - stacker://kernel-build/export/modules.squashfs
   run: |
@@ -23,15 +23,15 @@ bootkit-assemble:
 
     tar -C "$d" -xf /stacker/shim.tar
     tar -C "$d" -xf /stacker/uki.tar
-    tar -C "$d" -xf /stacker/ovmf.tar
+    tar -C "$d" -xf /stacker/virt-firmware.tar
 
     prepd="$d/bootkit"
     mkdir "$prepd"
     cp "$d/shim/shim.efi" "$prepd/shim.efi"
     cp "$d/uki/kernel.efi" "$prepd/kernel.efi"
-    cp "$d/ovmf/ovmf-vars.fd" "$prepd/ovmf-vars.fd"
-    cp "$d/ovmf/ovmf-vars-empty.fd" "$prepd/ovmf-vars-empty.fd"
-    cp "$d/ovmf/ovmf-code.fd" "$prepd/ovmf-code.fd"
+    cp "$d/virt-fw/virt-firmware-vars.fd" "$prepd/virt-firmware-vars.fd"
+    cp "$d/virt-fw/virt-firmware-vars-empty.fd" "$prepd/virt-firmware-vars-empty.fd"
+    cp "$d/virt-fw/virt-firmware-code.fd" "$prepd/virt-firmware-code.fd"
     cp /stacker/boot.tar /stacker/modules.squashfs "$prepd"
 
     mkdir /export

--- a/layers/build-krd/dracut/bootkit.conf
+++ b/layers/build-krd/dracut/bootkit.conf
@@ -1,1 +1,5 @@
-early_microcode="yes"
+if [ "${ARCH}" = "aarch64" ]; then
+    early_microcode="no"
+else
+    early_microcode="yes"
+fi

--- a/layers/build-krd/dracut/soci/module-setup.sh
+++ b/layers/build-krd/dracut/soci/module-setup.sh
@@ -33,7 +33,11 @@ install() {
         tpm2_nvread tpm2_nvreadpublic tpm2_pcrextend tpm2_pcrread \
         tpm2_policyauthorize tpm2_policynv tpm2_policypcr \
         tpm2_startauthsession tpm2_verifysignature tpm2_nvwrite
-    inst /usr/lib/x86_64-linux-gnu/libtss2-tcti-device.so.0
+    if [ "$ARCH" = "aarch64" ]; then
+        inst /usr/lib/aarch64-linux-gnu/libtss2-tcti-device.so.0
+    elif [ "$ARCH" = "x86_64" ]; then
+        inst /usr/lib/x86_64-linux-gnu/libtss2-tcti-device.so.0
+    fi
     inst curl
     inst git # needed for manifest reading, for now
     #inst /usr/ib/git-core/git-upload-pack

--- a/layers/build-krd/stacker.yaml
+++ b/layers/build-krd/stacker.yaml
@@ -9,6 +9,7 @@ build-krd-pkg:
     tag: minbase
   run: |
     #!/bin/bash -ex
+    ARCH=$(uname -m)
     pkgs=( )
     # packages used for initrd runtime or dracut initrd build.
     pkgs=( "${pkgs[@]}" 
@@ -30,7 +31,12 @@ build-krd-pkg:
     # packages used by build-initrd
     pkgs=( "${pkgs[@]}" cpio dracut-core fakeroot pigz )
     # firmware
-    pkgs=( "${pkgs[@]}" linux-firmware intel-microcode amd64-microcode )
+    if [ "$ARCH" = "x86_64" ]; then
+      pkgs=( "${pkgs[@]}" linux-firmware intel-microcode amd64-microcode )
+    elif [ "$ARCH" = "aarch64" ]; then
+      pkgs=( "${pkgs[@]}" linux-firmware util-linux )
+    fi
+    
     # uki tools
     pkgs=( "${pkgs[@]}" efitools pigz )
 

--- a/layers/mos/stacker.yaml
+++ b/layers/mos/stacker.yaml
@@ -8,7 +8,8 @@ mos-build:
     type: built
     tag: build-krd
   import:
-    - ${{MOSCTL_BINARY:https://github.com/project-machine/mos/releases/download/0.0.9/mosctl}}
+    - ${{MOSCTL_BINARY:https://github.com/project-machine/mos/releases/download/0.0.11/mosctl}}
+    - ${{ZOT_BINARY:https://github.com/project-zot/zot/releases/download/v1.4.3/zot-linux-arm64-minimal}}
     - ${{ZOT_BINARY:https://github.com/project-zot/zot/releases/download/v1.4.3/zot-linux-amd64-minimal}}
     - zot-config.json
   run: |
@@ -23,7 +24,13 @@ mos-build:
     cp /stacker/zot-config.json "$workd/etc/"
 
     mkdir -p "$workd/usr/bin"
-    for bin in mosctl:mosctl zot-linux-amd64-minimal:zot ; do
+    ARCH=$(uname -m)
+    if [ "$ARCH" = "aarch64" ]; then
+      zotarch=arm64
+    else
+      zotarch=amd64
+    fi
+    for bin in mosctl:mosctl zot-linux-${zotarch}-minimal:zot ; do
       t=$workd/usr/bin/${bin#*:}
       cp -v /stacker/${bin%:*} $t
       chmod 755 $t

--- a/layers/shim/stacker.yaml
+++ b/layers/shim/stacker.yaml
@@ -28,6 +28,7 @@ shim-build:
     d=$(mktemp -d)
     trap "rm -Rf $d" EXIT
 
+    ARCH=$(uname -m)
     cd $d
     keydir=$(echo /import/keys/*)
     [ -d "$keydir" ]
@@ -80,7 +81,12 @@ shim-build:
     sha256sum *.efi
 
     mkdir $d/shim
-    cp $shimd/shimx64.efi $d/shim/shim-unsigned.efi
+    if [ "$ARCH" = "x86_64" ]; then
+      cp $shimd/shimx64.efi $d/shim/shim-unsigned.efi
+    elif [ "$ARCH" = "aarch64" ]; then
+      cp $shimd/shimaa64.efi $d/shim/shim-unsigned.efi
+    fi
+
     sbsign \
         "--cert=$keydir/uefi-db/cert.pem" \
         "--key=$keydir/uefi-db/privkey.pem" \

--- a/layers/stubby/stacker.yaml
+++ b/layers/stubby/stacker.yaml
@@ -16,7 +16,7 @@ stubby-build:
     type: built
     tag: stubby-build-env
   import:
-    - "https://github.com/puzzleos/stubby/archive/refs/tags/v1.0.1.tar.gz"
+    - https://github.com/puzzleos/stubby/archive/refs/tags/v1.0.2.tar.gz
   run: |
     #!/bin/bash -ex
     tarball=$(echo /stacker/v*.tar.gz)

--- a/layers/uki/stacker.yaml
+++ b/layers/uki/stacker.yaml
@@ -49,7 +49,7 @@ uki-build:
     tar -C "$d" -xf /stacker/stubby.tar
     [ -f "$stubefi" ] ||
         { echo "stubby.tar did not have a stubby/stubby.efi"; exit 1; }
-
+    stubefi="/usr/lib/systemd/boot/efi/linuxaa64.efi.stub"
     keyworkd="$d/keyworkd"
     mkdir "$keyworkd"
     cp "$keydir/manifest-ca/cert.pem" "$keyworkd/manifestCA.pem"

--- a/layers/uki/stacker.yaml
+++ b/layers/uki/stacker.yaml
@@ -49,7 +49,6 @@ uki-build:
     tar -C "$d" -xf /stacker/stubby.tar
     [ -f "$stubefi" ] ||
         { echo "stubby.tar did not have a stubby/stubby.efi"; exit 1; }
-    stubefi="/usr/lib/systemd/boot/efi/linuxaa64.efi.stub"
     keyworkd="$d/keyworkd"
     mkdir "$keyworkd"
     cp "$keydir/manifest-ca/cert.pem" "$keyworkd/manifestCA.pem"

--- a/layers/virt-firmware/stacker.yaml
+++ b/layers/virt-firmware/stacker.yaml
@@ -2,20 +2,27 @@ config:
   prerequisites:
     - ../minbase/stacker.yaml
 
-ovmf-build-env:
+virt-firmware-build-env:
   build_only: true
   from:
     type: built
     tag: minbase
   run: |
-    pkgtool install python3 python3-pip ovmf
+    pkgtool install python3 python3-pip 
+    ARCH=$(uname -m)
+    if [ "$ARCH" = "aarch64" ]; then
+      pkgtool install qemu-system-arm qemu-efi-aarch64
+    else
+      pkgtool install ovmf
+    fi
+    
     pip install virt-firmware
 
-ovmf-build:
+virt-firmware-build:
   build_only: true
   from:
     type: built
-    tag: ovmf-build-env
+    tag: virt-firmware-build-env
   import:
     - path: ${{KEYSET_D}}/
       dest: /import/keys/
@@ -23,7 +30,9 @@ ovmf-build:
     d=$(mktemp -d)
     trap "rm -Rf $d" EXIT
 
-    mkdir "$d/ovmf"
+    ARCH=$(uname -m)
+
+    mkdir "$d/virt-fw"
     keydir=$(echo /import/keys/*)
     [ -d "$keydir" ]
 
@@ -56,10 +65,16 @@ ovmf-build:
       echo "$guid" "$certf"
     }
 
-    codef=/usr/share/OVMF/OVMF_CODE.secboot.fd
-    varsf=/usr/share/OVMF/OVMF_VARS.fd
-    cp "$codef" "$d/ovmf/ovmf-code.fd"
-    cp "$varsf" "$d/ovmf/ovmf-vars-empty.fd"
+    if [ "$ARCH" = "aarch64" ]; then
+      codef=/usr/share/AAVMF/AAVMF_CODE.ms.fd
+      varsf=/usr/share/AAVMF/AAVMF_VARS.ms.fd
+    else
+      codef=/usr/share/OVMF/OVMF_CODE.secboot.fd
+      varsf=/usr/share/OVMF/OVMF_VARS.fd
+    fi
+    
+    cp "$codef" "$d/virt-fw/virt-firmware-code.fd"
+    cp "$varsf" "$d/virt-fw/virt-firmware-vars-empty.fd"
     set +x
     set -- \
        --set-pk  $(getGuidCert "$keydir" uefi-pk) \
@@ -70,10 +85,10 @@ ovmf-build:
     set -x
     virt-fw-vars \
       "--input=$varsf" \
-      "--output=$d/ovmf/ovmf-vars.fd" \
+      "--output=$d/virt-fw/virt-firmware-vars.fd" \
       --secure-boot \
       --no-microsoft \
       "$@"
 
     mkdir /export
-    tar -C "$d" -cvf /export/ovmf.tar ovmf
+    tar -C "$d" -cvf /export/virt-firmware.tar virt-fw

--- a/subs.mk
+++ b/subs.mk
@@ -1,5 +1,8 @@
 KEYSET ?= snakeoil
 DOCKER_BASE ?= docker://
+ifeq (${ARCH},aarch64)
+UBUNTU_MIRROR := http://ports.ubuntu.com/ubuntu-ports
+endif
 UBUNTU_MIRROR ?= http://archive.ubuntu.com/ubuntu
 KEYSET_D ?= $(HOME)/.local/share/machine/trust/keys/$(KEYSET)
 


### PR DESCRIPTION
Bootkit can still build on both x86 and arm64 with the changes. However, it needs to be readapted to be compatible with the latest main as I pulled from commit c9b5115ac59e3b133bab9d749d88a5e978e15a6c.
Signed-off-by: Ashwin Gopalan <agopalan@berkeley.edu>