### PR TITLE
Add the pkg/util code which escaped the last PR.

### DIFF
--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"io"
+	"os"
+)
+
+func CopyFileContents(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Sync()
+}


### PR DESCRIPTION
pkg/util/file.go was in my local tree but missed getting into the PR. Luckily, it had only one function, CopyFileContents.