### PR TITLE
Fix calculation of MAIN_VERSION (and SERIAL_VERSION)

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1,8 +1,7 @@
 TOP_D := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 
 MAIN_VERSION = $(shell git describe --tags --always \
-        "--match=[0-9].[0-9]*" "--match=[0-9][0-9].[0-9]*" \
-        "--match=[0-9]-dev[0-9]*" "--match=[0-9][0-9]-dev[0-9]" \
+        "--match=v[0-9].[0-9]*" "--match=v[0-9][0-9].[0-9]*" \
         || echo no-git)
 ifeq ($(MAIN_VERSION),$(filter $(MAIN_VERSION), "", no-git))
 $(error "Bad value for MAIN_VERSION: '$(MAIN_VERSION)'")


### PR DESCRIPTION
We want to use v0.0.9, not 0.0.9, so that golang will find our versions.