### PR TITLE
Don't overwrite the saved pcr7.bin

### DIFF
--- a/layers/build-krd/dracut/soci/soci-settled.sh
+++ b/layers/build-krd/dracut/soci/soci-settled.sh
@@ -228,7 +228,9 @@ soci_udev_settled() {
                soci_info "Preinstall completed"
                ;;
             provision)
-               soci_log_run tpm2_pcrread sha256:7 -o /sysroot/pcr7.bin > /sysroot/pcr7.out
+               if [ ! -f /sysroot/pcr7.bin ]; then
+                   soci_log_run tpm2_pcrread sha256:7 -o /sysroot/pcr7.bin > /sysroot/pcr7.out
+               fi
                soci_log_run tpm2_pcrextend "7:sha256=b7135cbb321a66fa848b07288bd008b89bd5b7496c4569c5e1a4efd5f7c8e0a7"
                soci_info "PCR7 has been extended.  Ready to provision."
                ;;


### PR DESCRIPTION
If we've previously saved /pcr7.bin and extended syroot (as we may have done while verifying a manifest), then do not overwrite that file.  Do re-extedn pcr7 in case someone's playing games with us.