### PR TITLE
[RFC] soci-settled: mount /lib/modules

### DIFF
--- a/layers/build-krd/dracut/soci/soci-settled.sh
+++ b/layers/build-krd/dracut/soci/soci-settled.sh
@@ -247,6 +247,10 @@ soci_udev_settled() {
                if [ "$name" = "mosboot" ]; then
                    mkdir -p /sysroot/factory
                    soci_log_run mount --move /priv/factory /sysroot/factory
+                   soci_log_run mkdir /bootkit
+                   soci_log_run mosctl --debug mount --target bootkit /bootkit
+                   soci_log_run mkdir -p /sysroot/lib/modules
+                   soci_log_run mount /bootkit/bootkit/modules.squashfs /sysroot/lib/modules
                 fi
                soci_info "TPM is ready for general boot"
                ;;


### PR DESCRIPTION
When booting a full mos system, mount /lib/modules from modules.quashfs in the bootkit layer.