### PR TITLE
Publish 4M versions of ovmf firmware rather than 2M versions.

### DIFF
--- a/layers/ovmf/stacker.yaml
+++ b/layers/ovmf/stacker.yaml
@@ -21,8 +21,8 @@ ovmf-build:
 
     mkdir "$d/ovmf"
 
-    codef=/usr/share/OVMF/OVMF_CODE.secboot.fd
-    varsf=/usr/share/OVMF/OVMF_VARS.fd
+    codef=/usr/share/OVMF/OVMF_CODE_4M.secboot.fd
+    varsf=/usr/share/OVMF/OVMF_VARS_4M.fd
     cp "$codef" "$d/ovmf/ovmf-code.fd"
     cp "$varsf" "$d/ovmf/ovmf-vars.fd"
 


### PR DESCRIPTION
I'm not aware of a reason that 4M versions would not be preferred. The ovmf/README.debian file says of the 2M versions:

> These images are the same as their "4M" variants, but for use with guests
> using a 2MB flash device. 2MB flash is no longer considered sufficient for
> use with Secure Boot. This is provided only for backwards compatibility.