### PR TITLE
Delete /tmp/setvendordb file when done

### DIFF
--- a/go/pkg/shim/shim.go
+++ b/go/pkg/shim/shim.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"unsafe"
 
 	efi "github.com/canonical/go-efilib"
@@ -73,8 +74,10 @@ func SetVendorDB(shim string, db, dbx efi.SignatureDatabase) error {
 	if err != nil {
 		return err
 	}
+	defer os.Remove(fp.Name())
 
 	if err := VendorDBSectionWrite(fp, db, dbx); err != nil {
+		fp.Close()
 		return err
 	}
 


### PR DESCRIPTION
Hopefully we are in fact done with it after this function...  Right now every time I create a keyset one of these files leaks.