### PR TITLE
bump mos to v0.0.28

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           stacker --version
 
           sudo wget --progress=dot:mega -O /usr/bin/trust \
-              https://github.com/project-machine/mos/releases/download/v0.0.26/trust-linux-amd64
+              https://github.com/project-machine/mos/releases/download/v0.0.28/trust-linux-amd64
           sudo chmod 755 /usr/bin/trust
           trust keyset add snakeoil
       - name: build golang

--- a/subs.mk
+++ b/subs.mk
@@ -2,7 +2,7 @@ KEYSET ?= snakeoil
 DOCKER_BASE ?= docker://
 UBUNTU_MIRROR ?= http://archive.ubuntu.com/ubuntu
 KEYSET_D ?= $(HOME)/.local/share/machine/trust/keys/$(KEYSET)
-MOSCTL_BINARY ?= https://github.com/project-machine/mos/releases/download/v0.0.26/mosctl-linux-amd64
+MOSCTL_BINARY ?= https://github.com/project-machine/mos/releases/download/v0.0.28/mosctl-linux-amd64
 ZOT_BINARY ?= https://github.com/project-zot/zot/releases/download/v2.0.0-rc5/zot-linux-amd64-minimal
 
 STACKER_SUBS = \


### PR DESCRIPTION
v0.0.28 is a temp fake release to get updated mosctl and trust which know about storage.

Once we have bootkit/rfs layers with a mosctl which knows about storage, we can have mos use those new layers and actually work.