### PR TITLE
fix some 'imports' errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           sudo chmod 755 /usr/bin/zot
           which zot
           sudo wget --progress=dot:mega -O /usr/bin/stacker \
-              https://github.com/project-stacker/stacker/releases/download/v1.0.0-rc5/stacker
+              https://github.com/project-stacker/stacker/releases/download/v1.0.0/stacker
           sudo chmod 755 /usr/bin/stacker
           which stacker
           stacker --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,19 +31,9 @@ jobs:
           sudo chmod 755 /usr/bin/stacker
           which stacker
           stacker --version
-
-          sudo wget --progress=dot:mega -O /usr/bin/trust \
-              https://github.com/project-machine/mos/releases/download/v0.0.28/trust-linux-amd64
-          sudo chmod 755 /usr/bin/trust
-          trust keyset add snakeoil
       - name: build golang
         run: |
           make go-stacker-build
       - name: build layers
         run: |
           make STACKER_COMMON_OPTS=--debug
-      - name: Release bin
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
-        with:
-          files: pkg/bkcust

--- a/go/stacker.yaml
+++ b/go/stacker.yaml
@@ -7,7 +7,7 @@ buildenv-pkg:
   from:
     type: built
     tag: minbase
-  import:
+  imports:
     - https://go.dev/dl/go1.20.8.linux-amd64.tar.gz
   run: |
     pkgtool install gcc git libc6-dev make pkg-config \

--- a/layers/bootkit/stacker.yaml
+++ b/layers/bootkit/stacker.yaml
@@ -11,7 +11,7 @@ bootkit-assemble:
   from:
     type: built
     tag: build-krd
-  import:
+  imports:
     - stacker://kernel-build/export/initrd.tar
     - stacker://kernel-build/export/kernel.tar
     - stacker://mos-build/export/mos.tar

--- a/layers/build-krd/stacker.yaml
+++ b/layers/build-krd/stacker.yaml
@@ -59,10 +59,10 @@ build-krd:
   from:
     type: built
     tag: build-krd-pkg
-  import:
+  imports:
     - ../../tools/build-initrd
     - ../../tools/create-cpio
-    - dracut/
+    - dracut
   run: |
 
     importd=/stacker/imports

--- a/layers/custom/custom.yaml
+++ b/layers/custom/custom.yaml
@@ -30,7 +30,7 @@ customized:
   from:
     type: built
     tag: build-customize
-  import:
+  imports:
     - path: ../../tools/custbk
     - path: ../../pkg/bkcust
     - path: ${{KEYSET_D}}/

--- a/layers/minbase/stacker.yaml
+++ b/layers/minbase/stacker.yaml
@@ -3,7 +3,7 @@ minbase:
   from:
     type: docker
     url: ${{DOCKER_BASE}}ubuntu:jammy
-  import:
+  imports:
     - pkgtool
   run: |
     mirror=${{UBUNTU_MIRROR}}

--- a/layers/mos/stacker.yaml
+++ b/layers/mos/stacker.yaml
@@ -7,7 +7,7 @@ mos-build:
   from:
     type: built
     tag: build-krd
-  import:
+  imports:
     - path: ${{MOSCTL_BINARY}}
       dest: /imports/mosctl/mosctl
     - path: ${{ZOT_BINARY}}

--- a/layers/shim/stacker.yaml
+++ b/layers/shim/stacker.yaml
@@ -7,7 +7,7 @@ shim-build-env:
   from:
     type: built
     tag: minbase
-  import:
+  imports:
     - https://github.com/rhboot/shim/releases/download/15.6/shim-15.6.tar.bz2
   run: |
     pkgtool install libc6-dev openssl \

--- a/layers/stubby/stacker.yaml
+++ b/layers/stubby/stacker.yaml
@@ -15,7 +15,7 @@ stubby-build:
   from:
     type: built
     tag: stubby-build-env
-  import:
+  imports:
     - "https://github.com/puzzleos/stubby/archive/refs/tags/v1.0.1.tar.gz"
   run: |
     #!/bin/bash -ex


### PR DESCRIPTION
The stackerfiles were using import: but looking for files
under /stacker/imports.  You have to use imports: for that.

Also, imports: with an import of 'dracut/' will take all the contents of dracut/ and import them, rather than recursively import the dracut directory.  But we were expecting the dracut directory.  So drop the trailing slash.